### PR TITLE
Fix variable typo and doc summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Changelog
 
 1.1.3 - 1.11.2018
 
-- Fix: Fixed ticket summery generation
+- Fix: Fixed ticket summary generation
 
 1.1.2 - 31.10.2018
 

--- a/inc/worker/eer-ticket.worker.php
+++ b/inc/worker/eer-ticket.worker.php
@@ -80,8 +80,8 @@ class EER_Worker_Ticket {
 				], ['ticket_id' => $ticket_id, 'level_id' => null]);
 			}
 		} else {
-			$old_summery = EER()->ticket_summary->eer_get_ticket_summaries($ticket_id);
-			foreach ($old_summery as $summary_key => $summary) {
+                    $old_summary = EER()->ticket_summary->eer_get_ticket_summaries($ticket_id);
+                    foreach ($old_summary as $summary_key => $summary) {
 				if ($summary->level_id !== null) {
 					$level = $ticket_settings->levels->{$summary->level_id};
 


### PR DESCRIPTION
## Summary
- fix $old_summary typo in ticket worker
- update changelog wording in README

## Testing
- `grep -R "summery" -n`

------
https://chatgpt.com/codex/tasks/task_e_6842f668219c83219a60810be7ab93a6