### PR TITLE
Fix hosting checkbox visibility

### DIFF
--- a/inc/template/administration/order/subblock/eer-order-form.subblock.php
+++ b/inc/template/administration/order/subblock/eer-order-form.subblock.php
@@ -140,7 +140,7 @@ class EER_Template_Order_Edit_Form
 
 	public static function input_hosting($event_data)
 	{
-		if (intval(EER()->event->eer_get_event_option($event_data, 'offer_hosting_enabled', -1)) === 1) {
+               if (intval(EER()->event->eer_get_event_option($event_data, 'hosting_enabled', -1)) === 1) {
 			?>
 			<tr>
 				<th><?php _e('Offer hosting', 'easy-event-registration'); ?></th>


### PR DESCRIPTION
## Summary
- check `hosting_enabled` in admin order form

## Testing
- `php -l inc/template/administration/order/subblock/eer-order-form.subblock.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842f66ded4c8321ab0417a1146a454e