### PR TITLE
Fix comment typo

### DIFF
--- a/inc/class/eer-sl-plugin-updater.class.php
+++ b/inc/class/eer-sl-plugin-updater.class.php
@@ -358,7 +358,7 @@ class EER_SL_Plugin_Updater {
 	}
 
 	/**
-	 * Calls the API and, if successfull, returns the object delivered by the API.
+	 * Calls the API and, if successful, returns the object delivered by the API.
 	 *
 	 * @uses get_bloginfo()
 	 * @uses wp_remote_post()


### PR DESCRIPTION
## Summary
- fix typo `successfull` -> `successful` in EER_SL_Plugin_Updater

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842f67274a08321a07c0f0975ec10df