### PR TITLE
Add PHPUnit tests for EER_Fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,6 @@ Changelog
 - Fix: Solo tickets show / hide
 - Fix: Lots of small bug fixes
 
+## Running tests
+
+Install PHPUnit and execute `phpunit` from the repository root. The configuration file `phpunit.xml` is provided in the project.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Plugin Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/FieldsTest.php
+++ b/tests/FieldsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class FieldsTest extends TestCase
+{
+    /** @var EER_Fields */
+    private $fields;
+
+    protected function setUp(): void
+    {
+        $this->fields = new EER_Fields();
+    }
+
+    public function test_int_sanitize()
+    {
+        $this->assertSame(123, $this->fields->sanitize('int', '123'));
+    }
+
+    public function test_boolean_sanitize()
+    {
+        $this->assertTrue($this->fields->sanitize('boolean', 'true'));
+        $this->assertFalse($this->fields->sanitize('boolean', 'false'));
+    }
+
+    public function test_timestamp_sanitize()
+    {
+        $this->assertSame('2020-12-31 23:45', $this->fields->sanitize('timestamp', '2020-12-31 23:45:00'));
+    }
+
+    public function test_html_sanitize()
+    {
+        $this->assertSame("O\\'Reilly", $this->fields->sanitize('html', "O'Reilly"));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+// Define minimal WordPress constant to prevent early exit.
+define('ABSPATH', __DIR__);
+
+// Simple autoloader for plugin classes.
+spl_autoload_register(function ($class) {
+    $file = __DIR__ . '/../inc/class/' . strtolower(str_replace('_', '-', $class)) . '.class.php';
+    if (file_exists($file)) {
+        require $file;
+    }
+});


### PR DESCRIPTION
## Summary
- add phpunit config and bootstrap autoloader
- create test suite for `EER_Fields::sanitize`
- document how to run the test suite in README

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f6769f948321ab542ad8b9f6c8f4