### PR TITLE
Cleanup polyfill and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,4 +167,4 @@ Changelog
 
 ## Running tests
 
-Install PHPUnit and execute `phpunit` from the repository root. The configuration file `phpunit.xml` is provided in the project.
+Ensure PHP 8.1 and PHPUnit are installed, then execute `phpunit` from the repository root. The configuration file `phpunit.xml` is provided in the project.

--- a/easy-event-registration.php
+++ b/easy-event-registration.php
@@ -13,9 +13,8 @@
 
 // Exit if accessed directly.
 if (!defined('ABSPATH')) {
-	exit;
+        exit;
 }
-require_once __DIR__ . "/polyfill.php";
 
 if (!class_exists('Easy_Event_Registration')) {
 

--- a/polyfill.php
+++ b/polyfill.php
@@ -1,7 +1,0 @@
-<?php
-if (!function_exists('create_function')) {
-    function create_function($args, $code) {
-        $args = trim($args);
-        return eval('return function(' . $args . ') {' . $code . '};');
-    }
-}


### PR DESCRIPTION
## Summary
- remove obsolete `polyfill.php` and its require
- document PHP 8.1 requirement for running tests

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f7859d388321918b8be848ebca1c