### PR TITLE
Add GitHub Actions for PHPUnit tests

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,19 @@
+name: PHP Unit Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+          tools: phpunit
+      - name: Run PHPUnit
+        run: phpunit --configuration phpunit.xml


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs PHP 8.1 and runs PHPUnit

## Testing
- `phpunit --configuration phpunit.xml tests/FieldsTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fb85842c83219e14970b77c5d168