### PR TITLE
Add composer file and extend sanitize tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,4 +167,6 @@ Changelog
 
 ## Running tests
 
-Ensure PHP 8.1 and PHPUnit are installed, then execute `phpunit` from the repository root. The configuration file `phpunit.xml` is provided in the project.
+Run `composer install` to install the development dependencies. After that execute
+`vendor/bin/phpunit` from the repository root. The configuration file `phpunit.xml`
+is provided in the project.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
+    }
+}

--- a/tests/FieldsTest.php
+++ b/tests/FieldsTest.php
@@ -32,4 +32,15 @@ class FieldsTest extends TestCase
     {
         $this->assertSame("O\\'Reilly", $this->fields->sanitize('html', "O'Reilly"));
     }
+
+    public function test_json_sanitize()
+    {
+        $data = ['a' => 1, 'b' => true];
+        $this->assertSame($data, $this->fields->sanitize('json', $data));
+    }
+
+    public function test_default_sanitize()
+    {
+        $this->assertSame('Hello', $this->fields->sanitize('unknown', '<b>Hello</b>'));
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,3 +9,11 @@ spl_autoload_register(function ($class) {
         require $file;
     }
 });
+
+// Provide a simple replacement for WordPress's sanitize_text_field when running tests.
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($str)
+    {
+        return is_scalar($str) ? preg_replace('/[\r\n\t ]+/', ' ', trim(strip_tags($str))) : '';
+    }
+}


### PR DESCRIPTION
## Summary
- add composer.json with PHPUnit development dependency
- document running vendor\bin\phpunit after running composer install
- extend sanitize() test coverage for `json` and default cases
- provide sanitize_text_field polyfill for tests

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68430618cc248321a4eff25fb86e5e41