### PR TITLE
Add backend options for customizable emails and form

### DIFF
--- a/inc/class/eer-settings.class.php
+++ b/inc/class/eer-settings.class.php
@@ -33,9 +33,9 @@ class EER_Settings
 					],
 				],
 			]),
-			'style'      => apply_filters( 'eer_settings_style', [
-				'main'            => [
-				],
+                        'style'      => apply_filters( 'eer_settings_style', [
+                                'main'            => [
+                                ],
 				'normal_ticket'             => [
 					'normal_ticket_background'  => [
 						'id'       => 'normal_ticket_background',
@@ -271,11 +271,32 @@ class EER_Settings
 						'selector' => '.eer-tickets-sale-wrapper .eer-ticket-shop-form .btn.btn-default:hover',
 						'property' => 'font',
 					],
-				],
-			] ),
-			'licenses' => apply_filters('eer_settings_licenses', []),
-			'extensions' => apply_filters('eer_settings_extensions', []),
-		];
+                                ],
+                        ] ),
+                        'communication' => apply_filters('eer_settings_communication', [
+                                'emails' => [
+                                        'default_order_email_subject' => [
+                                                'id'   => 'default_order_email_subject',
+                                                'name' => __( 'Default Order Email Subject', 'easy-event-registration' ),
+                                                'type' => 'text',
+                                        ],
+                                        'default_order_email_body'    => [
+                                                'id'   => 'default_order_email_body',
+                                                'name' => __( 'Default Order Email Body', 'easy-event-registration' ),
+                                                'type' => 'full_editor',
+                                        ],
+                                ],
+                                'form'   => [
+                                        'registration_form_message' => [
+                                                'id'   => 'registration_form_message',
+                                                'name' => __( 'Registration Form Message', 'easy-event-registration' ),
+                                                'type' => 'full_editor',
+                                        ],
+                                ],
+                        ] ),
+                        'licenses' => apply_filters('eer_settings_licenses', []),
+                        'extensions' => apply_filters('eer_settings_extensions', []),
+                ];
 
 		return apply_filters('eer_registered_settings', $eer_settings);
 	}
@@ -294,19 +315,23 @@ class EER_Settings
 			'general' => apply_filters('eer_settings_sections_general', [
 				'main' => __('General', 'easy-event-registration'),
 			]),
-			'style' => apply_filters('eer_settings_sections_style', [
-				'main' => __('General', 'easy-event-registration'),
-				'normal_ticket' => __('Ticket', 'easy-event-registration'),
-				'sold_ticket' => __('Sold Ticket', 'easy-event-registration'),
-				'add_button' => __('Add Button', 'easy-event-registration'),
-				'remove_button' => __('Remove Button', 'easy-event-registration'),
-				'ticket_form' => __('Ticket Form', 'easy-event-registration'),
-				'user_form' => __('Registration Form', 'easy-event-registration'),
-				'confirm_button' => __('Confirm Button', 'easy-event-registration'),
-			]),
-			'licenses' => apply_filters('eer_settings_sections_licenses', []),
-			'extensions' => apply_filters('eer_settings_sections_extensions', []),
-		];
+                        'style' => apply_filters('eer_settings_sections_style', [
+                                'main' => __('General', 'easy-event-registration'),
+                                'normal_ticket' => __('Ticket', 'easy-event-registration'),
+                                'sold_ticket' => __('Sold Ticket', 'easy-event-registration'),
+                                'add_button' => __('Add Button', 'easy-event-registration'),
+                                'remove_button' => __('Remove Button', 'easy-event-registration'),
+                                'ticket_form' => __('Ticket Form', 'easy-event-registration'),
+                                'user_form' => __('Registration Form', 'easy-event-registration'),
+                                'confirm_button' => __('Confirm Button', 'easy-event-registration'),
+                        ]),
+                        'communication' => apply_filters('eer_settings_sections_communication', [
+                                'emails' => __( 'Emails', 'easy-event-registration' ),
+                                'form'   => __( 'Form', 'easy-event-registration' ),
+                        ]),
+                        'licenses' => apply_filters('eer_settings_sections_licenses', []),
+                        'extensions' => apply_filters('eer_settings_sections_extensions', []),
+                ];
 
 		$sections = apply_filters('eer_settings_sections', $sections);
 
@@ -317,16 +342,17 @@ class EER_Settings
 	public function eer_get_settings_tabs()
 	{
 
-		$settings = $this->eer_get_registered_settings();
+                $settings = $this->eer_get_registered_settings();
 
-		$tabs = [];
-		$tabs['general'] = __('General', 'easy-event-registration');
-		$tabs['style'] = __('Style', 'easy-event-registration');
+                $tabs = [];
+                $tabs['general'] = __('General', 'easy-event-registration');
+                $tabs['style'] = __('Style', 'easy-event-registration');
+                $tabs['communication'] = __('Communication', 'easy-event-registration');
 
-		if (!empty($settings['extensions'])) {
-			$tabs['extensions'] = __('Extensions', 'easy-event-registration');
-		}
-		if (!empty($settings['licenses'])) {
+                if (!empty($settings['extensions'])) {
+                        $tabs['extensions'] = __('Extensions', 'easy-event-registration');
+                }
+                if (!empty($settings['licenses'])) {
 			$tabs['licenses'] = __('Licenses', 'easy-event-registration');
 		}
 

--- a/inc/template/email/eer-order-email.template.php
+++ b/inc/template/email/eer-order-email.template.php
@@ -15,8 +15,14 @@ class EER_Template_Order_Email {
 
 		$user = get_user_by('ID', $order->user_id);
 
-		$subject = stripcslashes(EER()->event->eer_get_event_option($event_data, 'order_email_subject', ''));
-		$body    = stripcslashes(EER()->event->eer_get_event_option($event_data, 'order_email_body', null));
+                $subject = stripcslashes(EER()->event->eer_get_event_option($event_data, 'order_email_subject', ''));
+                if (empty($subject)) {
+                        $subject = stripcslashes(EER()->settings->eer_get_option('default_order_email_subject', ''));
+                }
+                $body    = stripcslashes(EER()->event->eer_get_event_option($event_data, 'order_email_body', null));
+                if ($body === null || $body === '') {
+                        $body = stripcslashes(EER()->settings->eer_get_option('default_order_email_body', ''));
+                }
 
 		if (!empty($body)) {
 			$tags = EER()->tags->get_tags('order_email');

--- a/inc/template/event_sale/eer-event-sale-user-form.template.php
+++ b/inc/template/event_sale/eer-event-sale-user-form.template.php
@@ -6,13 +6,17 @@ if (!defined('ABSPATH')) {
 
 class EER_Template_Event_Sale_User_Form {
 
-	public function print_content($event_id) {
-		$event_data = EER()->event->get_event_data($event_id);
-		?>
-		<form id="eer-ticket-shop-form" class="eer-ticket-shop-form"
-		      data-no-tickets="<?php _e('At least one ticket is required to select.', 'easy-event-registration'); ?>">
-			<div class="eer-form-tickets-header eer-clearfix">
-				<div class="eer-column-header"><span><?php _e('Item', 'easy-event-registration'); ?></span></div>
+        public function print_content($event_id) {
+                $event_data = EER()->event->get_event_data($event_id);
+                $form_message = stripcslashes(EER()->settings->eer_get_option('registration_form_message', ''));
+                ?>
+                <?php if (!empty($form_message)) { ?>
+                        <div class="eer-form-custom-message"><?php echo $form_message; ?></div>
+                <?php } ?>
+                <form id="eer-ticket-shop-form" class="eer-ticket-shop-form"
+                      data-no-tickets="<?php _e('At least one ticket is required to select.', 'easy-event-registration'); ?>">
+                        <div class="eer-form-tickets-header eer-clearfix">
+                                <div class="eer-column-header"><span><?php _e('Item', 'easy-event-registration'); ?></span></div>
 				<div class="eer-column-header eer-amount"><span><?php _e('Amount', 'easy-event-registration'); ?></span>
 				</div>
 				<div class="eer-column-header"><span><?php _e('Price', 'easy-event-registration'); ?></span></div>


### PR DESCRIPTION
## Summary
- allow setting default order email subject and body
- add configurable registration form message

## Testing
- ⚠️ `composer install` *(failed: CONNECT tunnel failed, response 403)*
- ⚠️ `vendor/bin/phpunit` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a19153c79883219d771cba6f987878