### PR TITLE
Secure AJAX handlers and fix translation path

### DIFF
--- a/easy-event-registration.php
+++ b/easy-event-registration.php
@@ -338,7 +338,7 @@ if (!class_exists('Easy_Event_Registration')) {
 
 			$mofile = sprintf('%1$s-%2$s.mo', 'easy-event-registration', $locale);
 
-			$mofile_local  = trailingslashit(EER_PLUGIN_URL . 'languages') . $mofile;
+                       $mofile_local  = trailingslashit(EER_PLUGIN_DIR . 'languages') . $mofile;
 			$mofile_global = WP_LANG_DIR . '/easy-event-registration/' . $mofile;
 
 			if (file_exists($mofile_global)) {

--- a/inc/class/eer-ajax.class.php
+++ b/inc/class/eer-ajax.class.php
@@ -7,20 +7,32 @@ if (!defined('ABSPATH')) {
 
 class EER_Ajax {
 
-	public static function eer_process_order_callback() {
-		$worker_event_sale = new EER_Worker_Event_Sale();
-		wp_send_json($worker_event_sale->process_registration(json_decode(stripslashes($_POST['order_data']))), 200);
-	}
+       public static function eer_process_order_callback() {
+               check_ajax_referer('eer_ajax_nonce', 'nonce');
+
+               $order_data_raw = isset($_POST['order_data']) ? wp_unslash($_POST['order_data']) : '';
+               $order_data     = json_decode(stripslashes($order_data_raw));
+
+               $worker_event_sale = new EER_Worker_Event_Sale();
+
+               wp_send_json($worker_event_sale->process_registration($order_data), 200);
+       }
 
 
-	public static function eer_remove_order_callback() {
-		if (isset($_POST['order_id'])) {
-			wp_send_json(apply_filters('eer_remove_order', $_POST['order_id']));
-			wp_die();
-		}
-		echo -1;
-		wp_die();
-	}
+       public static function eer_remove_order_callback() {
+               check_ajax_referer('eer_ajax_nonce', 'nonce');
+
+               if (!current_user_can('manage_options')) {
+                       wp_send_json_error('Unauthorized', 403);
+               }
+
+               if (isset($_POST['order_id'])) {
+                       $order_id = absint($_POST['order_id']);
+                       wp_send_json(apply_filters('eer_remove_order', $order_id));
+               }
+
+               wp_send_json_error('Missing order_id', 400);
+       }
 
 
 	public static function eer_remove_order_forever_callback() {
@@ -33,14 +45,20 @@ class EER_Ajax {
 	}
 
 
-	public static function eer_remove_sold_ticket_callback() {
-		if (isset($_POST['sold_ticket_id'])) {
-			wp_send_json(apply_filters('eer_remove_sold_ticket', $_POST['sold_ticket_id']));
-			wp_die();
-		}
-		echo -1;
-		wp_die();
-	}
+       public static function eer_remove_sold_ticket_callback() {
+               check_ajax_referer('eer_ajax_nonce', 'nonce');
+
+               if (!current_user_can('manage_options')) {
+                       wp_send_json_error('Unauthorized', 403);
+               }
+
+               if (isset($_POST['sold_ticket_id'])) {
+                       $sold_ticket_id = absint($_POST['sold_ticket_id']);
+                       wp_send_json(apply_filters('eer_remove_sold_ticket', $sold_ticket_id));
+               }
+
+               wp_send_json_error('Missing sold_ticket_id', 400);
+       }
 
 
 	public static function eer_confirm_sold_ticket_callback() {

--- a/inc/database/updates/eer-update.1.1.3.php
+++ b/inc/database/updates/eer-update.1.1.3.php
@@ -9,5 +9,8 @@ if (version_compare(get_site_option('eer_db_version'), '1.1.3', '<')) {
 		$ids[] = $result->id;
 	}
 
-	$wpdb->query("DELETE FROM {$wpdb->prefix}eer_ticket_summary WHERE id NOT IN (" . implode(",", $ids) . ")");
+       if (!empty($ids)) {
+               $placeholders = implode(',', array_fill(0, count($ids), '%d'));
+               $wpdb->query($wpdb->prepare("DELETE FROM {$wpdb->prefix}eer_ticket_summary WHERE id NOT IN ($placeholders)", $ids));
+       }
 }


### PR DESCRIPTION
## Summary
- Corrected localization loading to use filesystem path
- Added nonce, capability checks, and ID sanitization in AJAX callbacks
- Hardened database cleanup with prepared placeholders

## Testing
- `php -l easy-event-registration.php`
- `php -l inc/class/eer-ajax.class.php`
- `php -l inc/database/updates/eer-update.1.1.3.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a197b3eecc8321bdec8b880a5f42f6