### PR TITLE
style: use elseif for conditionals

### DIFF
--- a/easy-event-registration.php
+++ b/easy-event-registration.php
@@ -343,7 +343,7 @@ if (!class_exists('Easy_Event_Registration')) {
 
 			if (file_exists($mofile_global)) {
 				return load_textdomain('easy-event-registration', $mofile_global);
-			} else if (file_exists($mofile_local)) {
+			} elseif (file_exists($mofile_local)) {
 				return load_textdomain('easy-event-registration', $mofile_local);
 			} else {
 				return load_plugin_textdomain('easy-event-registration', false, dirname(plugin_basename(__FILE__)) . '/languages/');

--- a/inc/class/eer-settings.class.php
+++ b/inc/class/eer-settings.class.php
@@ -368,7 +368,7 @@ class EER_Settings
 
 		if ($tab && !empty($sections[$tab])) {
 			$tabs = $sections[$tab];
-		} else if ($tab) {
+		} elseif ($tab) {
 			$tabs = false;
 		}
 

--- a/inc/database/eer-database.php
+++ b/inc/database/eer-database.php
@@ -11,7 +11,7 @@ class EER_Database
 	{
 		if (get_site_option('eer_db_version') == NULL) {
 			self::database_install();
-		} else if (version_compare(get_site_option('eer_db_version', ''), EER_VERSION, '<')) {
+		} elseif (version_compare(get_site_option('eer_db_version', ''), EER_VERSION, '<')) {
 			self::database_update();
 		}
 	}

--- a/inc/eer-enqueue-scripts.php
+++ b/inc/eer-enqueue-scripts.php
@@ -58,7 +58,7 @@ class EER_Enqueue_Scripts {
 			self::eer_include_datatable_scripts();
 			wp_enqueue_script('tinymce');
 			wp_enqueue_style('wp-color-picker');
-		} else if (self::check_page_base(EER_Template_Order::MENU_SLUG) || self::check_page_base(EER_Template_Sold_Ticket::MENU_SLUG) || self::check_page_base(EER_Template_Payment_Emails::MENU_SLUG) || self::check_page_base(EER_Template_Tickets_In_Numbers::MENU_SLUG)) {
+		} elseif (self::check_page_base(EER_Template_Order::MENU_SLUG) || self::check_page_base(EER_Template_Sold_Ticket::MENU_SLUG) || self::check_page_base(EER_Template_Payment_Emails::MENU_SLUG) || self::check_page_base(EER_Template_Tickets_In_Numbers::MENU_SLUG)) {
 			wp_enqueue_script('eer_admin_events_script', EER_PLUGIN_URL . 'inc/assets/admin/js/eer-production.js', ['jquery']);
 			self::eer_include_admin_scripts();
 			self::eer_include_datatable_scripts();

--- a/inc/enum/eer-payment.enum.php
+++ b/inc/enum/eer-payment.enum.php
@@ -82,7 +82,7 @@ class EER_Enum_Payment
 			if ($user_payment->payment !== null) {
 				if (floatval($user_payment->to_pay) == $user_payment->payment) {
 					return EER_Enum_Payment::PAID;
-				} else if (floatval($user_payment->to_pay) > $user_payment->payment) {
+				} elseif (floatval($user_payment->to_pay) > $user_payment->payment) {
 					return EER_Enum_Payment::NOT_PAID_ALL;
 				} else {
 					return EER_Enum_Payment::OVER_PAID;

--- a/inc/model/eer-event.php
+++ b/inc/model/eer-event.php
@@ -475,7 +475,7 @@ class EER_Event {
 
 		if ( $tab && ! empty( $sections[ $tab ] ) ) {
 			$tabs = $sections[ $tab ];
-		} else if ( $tab ) {
+		} elseif ( $tab ) {
 			$tabs = false;
 		}
 

--- a/inc/model/eer-ticket.php
+++ b/inc/model/eer-ticket.php
@@ -131,7 +131,7 @@ class EER_Ticket {
 
 		if ($tab && !empty($sections[$tab])) {
 			$tabs = $sections[$tab];
-		} else if ($tab) {
+		} elseif ($tab) {
 			$tabs = false;
 		}
 

--- a/inc/template/administration/settings/eer-settings-helper.template.php
+++ b/inc/template/administration/settings/eer-settings-helper.template.php
@@ -351,7 +351,7 @@ class EER_Template_Settings_Helper
 
 		if (is_string($class)) {
 			$class = sanitize_html_class($class);
-		} else if (is_array($class)) {
+		} elseif (is_array($class)) {
 			$class = array_values(array_map('sanitize_html_class', $class));
 			$class = implode(' ', array_unique($class));
 		}

--- a/inc/template/helpers/eer-all-events-select.templater.php
+++ b/inc/template/helpers/eer-all-events-select.templater.php
@@ -42,9 +42,9 @@ class EER_Template_All_Events_Select {
 		if (isset($_POST['eer_choose_event_submit']) && isset($_POST['eer_event'])) {
 			update_user_meta(get_current_user_id(), 'eer_user_event_id', $_POST['eer_event']);
 			return $_POST['eer_event'];
-		} else if (count($user_saved_event) > 0) {
+		} elseif (count($user_saved_event) > 0) {
 			return $user_saved_event[0];
-		} else if ($events) {
+		} elseif ($events) {
 			return reset($events);
 		} else {
 			$events = EER()->event->load_events_without_data();

--- a/inc/template/helpers/eer-models-settings-helper.template.php
+++ b/inc/template/helpers/eer-models-settings-helper.template.php
@@ -336,7 +336,7 @@ class EER_Models_Settings_Helper_Templater {
 
 		if (is_string($class)) {
 			$class = sanitize_html_class($class);
-		} else if (is_array($class)) {
+		} elseif (is_array($class)) {
 			$class = array_values(array_map('sanitize_html_class', $class));
 			$class = implode(' ', array_unique($class));
 		}
@@ -357,7 +357,7 @@ class EER_Models_Settings_Helper_Templater {
 	public static function eer_check_default_value($args, $key, $default = '') {
 		if (isset($args['data']) && !empty($args['data']) && isset($args['data']->$key)) {
 			return $args['data']->$key;
-		} else if (isset($args['std'])) {
+		} elseif (isset($args['std'])) {
 			return $args['std'];
 		}
 

--- a/inc/template/helpers/filters/eer-event-tickets-filter.templater.php
+++ b/inc/template/helpers/filters/eer-event-tickets-filter.templater.php
@@ -41,7 +41,7 @@ class EER_Event_Tickets_Filter_Template {
 		if (isset($_POST['eer_choose_ticket_submit']) && isset($_POST['eer_ticket'])) {
 			update_user_meta(get_current_user_id(), 'eer_user_ticket_id', $_POST['eer_ticket']);
 			return $_POST['eer_ticket'];
-		} else if ((count($user_saved_ticket) > 0) && $ticket_data && (intval($ticket_data->event_id) === $selected_event)) {
+		} elseif ((count($user_saved_ticket) > 0) && $ticket_data && (intval($ticket_data->event_id) === $selected_event)) {
 			return $user_saved_ticket[0];
 		} else {
 			$tickets = EER()->ticket->get_tickets_by_event(($selected_event !== null) ? $selected_event : apply_filters('eer_all_events_select_get', []));

--- a/inc/worker/eer-ajax.worker.php
+++ b/inc/worker/eer-ajax.worker.php
@@ -24,15 +24,15 @@ class EER_Worker_Ajax {
 				if ($sold_ticket->status == EER_Enum_Sold_Ticket_Status::CONFIRMED) {
 					if (EER()->ticket->eer_is_solo($sold_ticket->ticket_id)) {
 						$update['registered_tickets'] = $summary->registered_tickets - 1;
-					} else if (EER()->dancing_as->eer_is_follower($sold_ticket->dancing_as)) {
+					} elseif (EER()->dancing_as->eer_is_follower($sold_ticket->dancing_as)) {
 						$update['registered_followers'] = $summary->registered_followers - 1;
-					} else if (EER()->dancing_as->eer_is_leader($sold_ticket->dancing_as)) {
+					} elseif (EER()->dancing_as->eer_is_leader($sold_ticket->dancing_as)) {
 						$update['registered_leaders'] = $summary->registered_leaders - 1;
 					}
-				} else if ($sold_ticket->status == EER_Enum_Sold_Ticket_Status::WAITING) {
+				} elseif ($sold_ticket->status == EER_Enum_Sold_Ticket_Status::WAITING) {
 					if (EER()->dancing_as->eer_is_follower($sold_ticket->dancing_as)) {
 						$update['waiting_followers'] = $summary->waiting_followers - 1;
-					} else if (EER()->dancing_as->eer_is_leader($sold_ticket->dancing_as)) {
+					} elseif (EER()->dancing_as->eer_is_leader($sold_ticket->dancing_as)) {
 						$update['waiting_leaders'] = $summary->waiting_leaders - 1;
 					}
 				}
@@ -87,15 +87,15 @@ class EER_Worker_Ajax {
 			if ($sold_ticket_data->status == EER_Enum_Sold_Ticket_Status::CONFIRMED) {
 				if (EER()->ticket->eer_is_solo($sold_ticket_data->ticket_id)) {
 					$update['registered_tickets'] = $summary->registered_tickets - 1;
-				} else if (EER()->dancing_as->eer_is_follower($sold_ticket_data->dancing_as)) {
+				} elseif (EER()->dancing_as->eer_is_follower($sold_ticket_data->dancing_as)) {
 					$update['registered_followers'] = $summary->registered_followers - 1;
-				} else if (EER()->dancing_as->eer_is_leader($sold_ticket_data->dancing_as)) {
+				} elseif (EER()->dancing_as->eer_is_leader($sold_ticket_data->dancing_as)) {
 					$update['registered_leaders'] = $summary->registered_leaders - 1;
 				}
-			} else if ($sold_ticket_data->status == EER_Enum_Sold_Ticket_Status::WAITING) {
+			} elseif ($sold_ticket_data->status == EER_Enum_Sold_Ticket_Status::WAITING) {
 				if (EER()->dancing_as->eer_is_follower($sold_ticket_data->dancing_as)) {
 					$update['waiting_followers'] = $summary->waiting_followers - 1;
-				} else if (EER()->dancing_as->eer_is_leader($sold_ticket_data->dancing_as)) {
+				} elseif (EER()->dancing_as->eer_is_leader($sold_ticket_data->dancing_as)) {
 					$update['waiting_leaders'] = $summary->waiting_leaders - 1;
 				}
 			}
@@ -177,19 +177,19 @@ class EER_Worker_Ajax {
 			if ($sold_ticket_data->status == EER_Enum_Sold_Ticket_Status::DELETED) {
 				if ($is_solo) {
 					$update['registered_tickets'] = $summary->registered_tickets + 1;
-				} else if (EER()->dancing_as->eer_is_follower($sold_ticket_data->dancing_as)) {
+				} elseif (EER()->dancing_as->eer_is_follower($sold_ticket_data->dancing_as)) {
 					$update['registered_followers'] = $summary->registered_followers + 1;
-				} else if (EER()->dancing_as->eer_is_leader($sold_ticket_data->dancing_as)) {
+				} elseif (EER()->dancing_as->eer_is_leader($sold_ticket_data->dancing_as)) {
 					$update['registered_leaders'] = $summary->registered_leaders + 1;
 				}
-			} else if ($sold_ticket_data->status == EER_Enum_Sold_Ticket_Status::WAITING) {
+			} elseif ($sold_ticket_data->status == EER_Enum_Sold_Ticket_Status::WAITING) {
 				if ($is_solo) {
 					$update['registered_tickets'] = $summary->registered_tickets + 1;
 					$update['waiting_tickets']    = $summary->waiting_tickets - 1;
-				} else if (EER()->dancing_as->eer_is_follower($sold_ticket_data->dancing_as)) {
+				} elseif (EER()->dancing_as->eer_is_follower($sold_ticket_data->dancing_as)) {
 					$update['registered_followers'] = $summary->registered_followers + 1;
 					$update['waiting_followers']    = $summary->waiting_followers - 1;
-				} else if (EER()->dancing_as->eer_is_leader($sold_ticket_data->dancing_as)) {
+				} elseif (EER()->dancing_as->eer_is_leader($sold_ticket_data->dancing_as)) {
 					$update['registered_leaders'] = $summary->registered_leaders + 1;
 					$update['waiting_leaders']    = $summary->waiting_leaders - 1;
 				}

--- a/inc/worker/eer-event-sale-couple.worker.php
+++ b/inc/worker/eer-event-sale-couple.worker.php
@@ -213,7 +213,7 @@ class EER_Event_Sale_Couple_Worker {
 
 					$return_tickets['paired'][$ticket_id][$sold_ticket_id]['user']['sold_ticket_id'] = (int) $sold_ticket_id;
 					$return_tickets['paired'][$ticket_id][$sold_ticket_id]['partner']['sold_ticket_id'] = (int) $partner_reg[0]->id;
-				} else if (EER()->pairing_mode->is_auto_confirmation_enabled($ticket_data->pairing_mode)) {
+				} elseif (EER()->pairing_mode->is_auto_confirmation_enabled($ticket_data->pairing_mode)) {
 					// Confirm all registrations until course is full
 					$wpdb->update($wpdb->prefix . 'eer_sold_tickets', [
 						'status' => EER_Enum_Sold_Ticket_Status::CONFIRMED

--- a/inc/worker/eer-event-sale.worker.php
+++ b/inc/worker/eer-event-sale.worker.php
@@ -147,7 +147,7 @@ class EER_Worker_Event_Sale {
 				} else {
 					if (EER()->dancing_as->eer_is_leader($ticket->dancing_as)) {
 						$test_full = EER()->dancing_as->eer_is_leader_registration_enabled($ticket_id, ((isset($ticket->level_id) && ($ticket->level_id !== '')) ? $ticket->level_id : null));
-					} else if (EER()->dancing_as->eer_is_follower($ticket->dancing_as)) {
+					} elseif (EER()->dancing_as->eer_is_follower($ticket->dancing_as)) {
 						$test_full = EER()->dancing_as->eer_is_followers_registration_enabled($ticket_id, ((isset($ticket->level_id) && ($ticket->level_id !== '')) ? $ticket->level_id : null));
 					}
 				}

--- a/inc/worker/eer-event.worker.php
+++ b/inc/worker/eer-event.worker.php
@@ -89,7 +89,7 @@ class EER_Worker_Event {
 				}
 
 				$return_data[ $key ] = json_encode( EER()->fields->eer_sanitize_event_settings( $data[ $key ] ) );
-			} else if ( ( $field['required'] && ! $is_update ) || isset( $data[ $key ] ) ) {
+			} elseif ( ( $field['required'] && ! $is_update ) || isset( $data[ $key ] ) ) {
 				$return_data[ $key ] = EER()->fields->sanitize( $field['type'], $data[ $key ] );
 			}
 		}

--- a/inc/worker/eer-ticket.worker.php
+++ b/inc/worker/eer-ticket.worker.php
@@ -137,9 +137,9 @@ class EER_Worker_Ticket {
 				$return_data['has_levels'] = (isset($data[$key]['levels_enabled']) && (intval($data[$key]['levels_enabled']) === 1));
 
 				$return_data[$key] = json_encode(EER()->fields->eer_sanitize_ticket_settings($data[$key]), JSON_FORCE_OBJECT);
-			} else if (($field['type'] === 'boolean') && (!isset($data[$key]) || (isset($data[$key]) && !is_bool($data[$key])))) {
+			} elseif (($field['type'] === 'boolean') && (!isset($data[$key]) || (isset($data[$key]) && !is_bool($data[$key])))) {
 				$return_data[$key] = isset($data[$key]) && ($data[$key] === '1');
-			} else if (($field['required'] && !$is_update) || isset($data[$key])) {
+			} elseif (($field['required'] && !$is_update) || isset($data[$key])) {
 				$return_data[$key] = EER()->fields->sanitize($field['type'], $data[$key]);
 			}
 		}


### PR DESCRIPTION
## Summary
- replace `else if` with `elseif` to follow WordPress PHP coding conventions

## Testing
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ea25f5f0832185bb5116d273e344