### PR TITLE
Allow null sale dates for events

### DIFF
--- a/inc/database/eer-database.php
+++ b/inc/database/eer-database.php
@@ -39,10 +39,11 @@ class EER_Database
 		include_once 'updates/eer-update.1.1.2.php';
 		include_once 'updates/eer-update.1.1.3.php';
 		include_once 'updates/eer-update.1.2.3.php';
-		include_once 'updates/eer-update.1.2.6.php';
-		include_once 'updates/eer-update.1.3.2.php';
-		update_option('eer_db_version', EER_VERSION);
-	}
+                include_once 'updates/eer-update.1.2.6.php';
+                include_once 'updates/eer-update.1.3.2.php';
+                include_once 'updates/eer-update.1.3.3.php';
+                update_option('eer_db_version', EER_VERSION);
+        }
 
 	public static function create_tables()
 	{
@@ -50,15 +51,15 @@ class EER_Database
 
 		$charset_collate = $wpdb->get_charset_collate();
 
-		$sql = "CREATE TABLE {$wpdb->prefix}eer_events (
-			id bigint(20) NOT NULL AUTO_INCREMENT,
-			is_passed boolean NOT NULL DEFAULT FALSE,
-			title mediumtext NOT NULL,
-			sale_start timestamp NOT NULL,
-			sale_end timestamp NOT NULL,
-			event_settings longtext,
-			PRIMARY KEY id (id)
-		) $charset_collate;";
+                $sql = "CREATE TABLE {$wpdb->prefix}eer_events (
+                        id bigint(20) NOT NULL AUTO_INCREMENT,
+                        is_passed boolean NOT NULL DEFAULT FALSE,
+                        title mediumtext NOT NULL,
+                        sale_start timestamp NULL DEFAULT NULL,
+                        sale_end timestamp NULL DEFAULT NULL,
+                        event_settings longtext,
+                        PRIMARY KEY id (id)
+                ) $charset_collate;";
 
 		$sql .= "CREATE TABLE {$wpdb->prefix}eer_tickets (
 			id bigint(20) NOT NULL AUTO_INCREMENT,

--- a/inc/database/updates/eer-update.1.3.3.php
+++ b/inc/database/updates/eer-update.1.3.3.php
@@ -1,0 +1,8 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+global $wpdb;
+$wpdb->query("ALTER TABLE {$wpdb->prefix}eer_events MODIFY sale_start timestamp NULL DEFAULT NULL, MODIFY sale_end timestamp NULL DEFAULT NULL;");
+

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -1,0 +1,22 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../inc/database/eer-database.php';
+
+class DatabaseTest extends TestCase
+{
+    public function test_events_table_allows_null_sale_dates()
+    {
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = '';
+            public function get_charset_collate() { return ''; }
+        };
+
+        $GLOBALS['last_sql'] = '';
+        EER_Database::create_tables();
+        $this->assertStringContainsString('sale_start timestamp NULL', $GLOBALS['last_sql']);
+        $this->assertStringContainsString('sale_end timestamp NULL', $GLOBALS['last_sql']);
+    }
+}
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,13 @@
 <?php
 // Define minimal WordPress constant to prevent early exit.
-define('ABSPATH', __DIR__);
+define('ABSPATH', __DIR__ . '/');
+
+// Stub WordPress hooks.
+if (!function_exists('add_action')) {
+    function add_action($tag, $function_to_add) {
+        // no-op for tests
+    }
+}
 
 // Simple autoloader for plugin classes.
 spl_autoload_register(function ($class) {

--- a/tests/wp-admin/includes/upgrade.php
+++ b/tests/wp-admin/includes/upgrade.php
@@ -1,0 +1,5 @@
+<?php
+function dbDelta($sql) {
+    $GLOBALS['last_sql'] = $sql;
+}
+


### PR DESCRIPTION
## Summary
- allow events sale_start and sale_end columns to accept NULL values
- add database update script and tests to verify schema
- centralize WordPress stubs for database tests

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a21042857083219074e65e022a91f0