### PR TITLE
Add debug logging and quick instructions to Easy Event admin page

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,17 @@ Changelog
 Run `composer install` to install the development dependencies. After that execute
 `vendor/bin/phpunit` from the repository root. The configuration file `phpunit.xml`
 is provided in the project.
+
+## Debugging
+
+Enable detailed plugin logging by defining the `EER_DEBUG` constant as `true`. Log
+messages are written to `eer-debug.log` in the plugin root directory.
+
+You can verify the logger independently by running the demo script:
+
+```
+php tests/debug_demo.php
+```
+
+The script writes a sample entry to `tests/debug.log` so you can confirm that
+debugging is working.

--- a/inc/class/eer-debug.class.php
+++ b/inc/class/eer-debug.class.php
@@ -1,0 +1,39 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class EER_Debug
+{
+    private static $enabled = null;
+    private static $log_file = null;
+
+    public static function init($enabled = null, $log_file = null)
+    {
+        self::$enabled = $enabled ?? (defined('EER_DEBUG') ? EER_DEBUG : false);
+        self::$log_file = $log_file ?? __DIR__ . '/../..' . '/eer-debug.log';
+    }
+
+    public static function log($message)
+    {
+        if (self::$enabled === null) {
+            self::init();
+        }
+
+        if (!self::$enabled) {
+            return;
+        }
+
+        $date = date('Y-m-d H:i:s');
+        $entry = '[' . $date . '] ' . $message . PHP_EOL;
+        file_put_contents(self::$log_file, $entry, FILE_APPEND);
+    }
+
+    public static function get_log_file()
+    {
+        if (self::$log_file === null) {
+            self::init();
+        }
+        return self::$log_file;
+    }
+}

--- a/inc/eer-enqueue-scripts.php
+++ b/inc/eer-enqueue-scripts.php
@@ -48,15 +48,15 @@ class EER_Enqueue_Scripts {
 
 	public static function add_admin_scripts() {
 
-		$eer_scripts = [
-			EER_Template_Payments::MENU_SLUG => [
-				'eer_scripts_default_admin',
-				'eer_scripts_datatable',
-			],
-			EER_Admin::ADMIN_MENU_SLUG       => [
-				'eer_scripts_default_admin',
-			]
-		];
+                $eer_scripts = [
+                        EER_Template_Payments::MENU_SLUG => [
+                                'eer_scripts_default_admin',
+                                'eer_scripts_datatable',
+                        ],
+                        EER_Admin::ADMIN_MENU_SLUG       => [
+                                'eer_scripts_admin_home',
+                        ]
+                ];
 
 		if (self::check_page_base(EER_Template_Event::MENU_SLUG) || self::check_page_base(EER_Template_Ticket::MENU_SLUG)) {
 			wp_enqueue_script('eer_admin_events_script', EER_PLUGIN_URL . 'inc/assets/admin/js/eer-production.js', ['jquery', 'wp-color-picker']);
@@ -133,6 +133,11 @@ class EER_Enqueue_Scripts {
 		wp_enqueue_script('eer_bootstrap_script', EER_PLUGIN_URL . 'libs/bootstrap/js/bootstrap.min.js', ['jquery'], EER_VERSION);
 	}
 
+	public static function eer_scripts_admin_home_callback() {
+		wp_enqueue_style('eer_admin_style', EER_PLUGIN_URL . 'inc/assets/admin/css/eer-admin-settings.css', [], EER_VERSION);
+		wp_enqueue_style('eer_admin_bootstrap_style', EER_PLUGIN_URL . 'libs/bootstrap/css/bootstrap-ofic.css', [], EER_VERSION);
+	}
+
 
 	public static function eer_scripts_datatable_callback() {
 		wp_enqueue_script('eer_dataTables_script', EER_PLUGIN_URL . 'libs/datatable/datatables.min.js', ['jquery'], EER_VERSION);
@@ -161,4 +166,5 @@ add_action('admin_enqueue_scripts', ['EER_Enqueue_Scripts', 'add_admin_scripts']
 
 //Script calls
 add_action('eer_scripts_default_admin', ['EER_Enqueue_Scripts', 'eer_scripts_default_admin_callback']);
+add_action('eer_scripts_admin_home', ['EER_Enqueue_Scripts', 'eer_scripts_admin_home_callback']);
 add_action('eer_scripts_datatable', ['EER_Enqueue_Scripts', 'eer_scripts_datatable_callback']);

--- a/inc/template/administration/easy-event/eer-easy-event.templater.php
+++ b/inc/template/administration/easy-event/eer-easy-event.templater.php
@@ -8,23 +8,36 @@ if (!defined('ABSPATH')) {
 class EER_Template_Easy_Event
 {
 
-	public static function print_page()
-	{
-		?>
-		<div class="wrap eer-settings">
+        public static function print_page()
+        {
+                if (class_exists('EER_Debug')) {
+                        EER_Debug::log('Easy Event admin page accessed');
+                }
+                ?>
+                <div class="wrap eer-settings">
 			<h1 class="wp-heading-inline"><?php echo __('Easy Event Registration', 'easy-event-registration') . ' ' . __('(EER)', 'easy-event-registration'); ?></h1>
-			<h2><?php _e('All-in-One Registration Management Tool', 'easy-event-registration'); ?></h2>
+                        <h2><?php _e('All-in-One Registration Management Tool', 'easy-event-registration'); ?></h2>
 
-			<p><?php _e('EER is the <strong>free</strong> to-go tool to run your school events with ease.', 'easy-event-registration'); ?></p>
+                        <p><?php _e('EER is the <strong>free</strong> to-go tool to run your school events with ease.', 'easy-event-registration'); ?></p>
 
-			<p><?php echo sprintf(__('How to get started? Follow the <strong><a href="%s" target="_blank">Quick-Start Guide</a></strong> to get up and running in no time!', 'easy-event-registration'), 'https://easyschoolregistration.com/docs/general/quick-start-guide-eer/'); ?></p>
+                        <p><?php _e('Use the plugin to create events, sell tickets and track registrations right from your WordPress dashboard.', 'easy-event-registration'); ?></p>
 
-			<p><?php _e('Need discounts, promo codes or potentially a custom feature?', 'easy-event-registration'); ?><br/>
-				<?php echo sprintf(__('Visit our <strong><a href="%s" target="_blank">website</a></strong> to check the available modules or get in touch with our team!', 'easy-event-registration'), 'https://easyschoolregistration.com/'); ?></p>
-			<br>
-			<p><?php _e('Questions or ideas? Need help with the setup?', 'easy-event-registration'); ?></p>
+                        <h3><?php _e('Quick instructions', 'easy-event-registration'); ?></h3>
+                        <ol>
+                                <li><?php _e('Create a new event and configure its details.', 'easy-event-registration'); ?></li>
+                                <li><?php _e('Add tickets for the event with prices and limits.', 'easy-event-registration'); ?></li>
+                                <li><?php _e('Publish the registration form and share it with participants.', 'easy-event-registration'); ?></li>
+                                <li><?php _e('Manage orders and payments from the dashboard.', 'easy-event-registration'); ?></li>
+                        </ol>
 
-			<p><?php echo sprintf(__('Check the <strong><a href="%s" target="_blank">Documentation</a></strong> or let us know via <strong><a href="%s" target="_blank">Contact form</a></strong>.', 'easy-event-registration'), 'https://easyschoolregistration.com/docs', 'https://easyschoolregistration.com/contact/'); ?></p>
+                        <p><?php echo sprintf(__('How to get started? Follow the <strong><a href="%s" target="_blank">Quick-Start Guide</a></strong> to get up and running in no time!', 'easy-event-registration'), 'https://easyschoolregistration.com/docs/general/quick-start-guide-eer/'); ?></p>
+
+                        <p><?php _e('Need discounts, promo codes or potentially a custom feature?', 'easy-event-registration'); ?><br/>
+                                <?php echo sprintf(__('Visit our <strong><a href="%s" target="_blank">website</a></strong> to check the available modules or get in touch with our team!', 'easy-event-registration'), 'https://easyschoolregistration.com/'); ?></p>
+                        <br>
+                        <p><?php _e('Questions or ideas? Need help with the setup?', 'easy-event-registration'); ?></p>
+
+                        <p><?php echo sprintf(__('Check the <strong><a href="%s" target="_blank">Documentation</a></strong> or let us know via <strong><a href="%s" target="_blank">Contact form</a></strong>.', 'easy-event-registration'), 'https://easyschoolregistration.com/docs', 'https://easyschoolregistration.com/contact/'); ?></p>
 
 			<p class="eer-socials">
 				<a href="https://www.facebook.com/easyschoolregistration/" target="_blank"><i class="fab fa-facebook-square"></i></a>

--- a/tests/DebugLogTest.php
+++ b/tests/DebugLogTest.php
@@ -1,0 +1,18 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../inc/class/eer-debug.class.php';
+
+class DebugLogTest extends TestCase
+{
+    public function test_log_creates_file()
+    {
+        $log = tempnam(sys_get_temp_dir(), 'eer');
+        EER_Debug::init(true, $log);
+        EER_Debug::log('hello');
+        $this->assertFileExists($log);
+        $this->assertStringContainsString('hello', file_get_contents($log));
+        unlink($log);
+    }
+}

--- a/tests/debug_demo.php
+++ b/tests/debug_demo.php
@@ -1,0 +1,8 @@
+<?php
+require __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../inc/class/eer-debug.class.php';
+
+EER_Debug::init(true, __DIR__ . '/debug.log');
+EER_Debug::log('Debugging is working');
+
+echo 'Debug log written to ' . EER_Debug::get_log_file() . PHP_EOL;


### PR DESCRIPTION
## Summary
- Explain that the plugin handles event creation, ticket sales, and registration tracking
- Add concise step-by-step instructions to help users operate the plugin
- Add optional `EER_Debug` logger and record admin-page visits when enabled
- Provide demo script and PHPUnit test to verify debug logging

## Testing
- `php tests/debug_demo.php`
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a21aa7b85883219b8d6d850c2265d3