### PR TITLE
Log WP_Error details for easier debugging

### DIFF
--- a/inc/class/eer-debug.class.php
+++ b/inc/class/eer-debug.class.php
@@ -29,6 +29,27 @@ class EER_Debug
         file_put_contents(self::$log_file, $entry, FILE_APPEND);
     }
 
+    public static function log_wp_error($error)
+    {
+        if (!($error instanceof WP_Error)) {
+            return;
+        }
+
+        foreach ($error->get_error_codes() as $code) {
+            $messages = $error->get_error_messages($code);
+            $data     = $error->get_error_data($code);
+
+            foreach ($messages as $message) {
+                $entry = 'WP_Error ' . $code . ': ' . $message;
+                if (!empty($data)) {
+                    $json  = function_exists('wp_json_encode') ? wp_json_encode($data) : json_encode($data);
+                    $entry .= ' | Data: ' . $json;
+                }
+                self::log($entry);
+            }
+        }
+    }
+
     public static function get_log_file()
     {
         if (self::$log_file === null) {

--- a/inc/worker/eer-event-sale.worker.php
+++ b/inc/worker/eer-event-sale.worker.php
@@ -131,8 +131,12 @@ class EER_Worker_Event_Sale {
 			}
 		}
 
-		return count($eer_reg_errors->get_error_messages()) === 0;
-	}
+                $valid = count($eer_reg_errors->get_error_messages()) === 0;
+                if (!$valid && class_exists('EER_Debug')) {
+                        EER_Debug::log_wp_error($eer_reg_errors);
+                }
+                return $valid;
+        }
 
 
 	private function eer_get_valid_data($data, $limit_validation = true) {

--- a/tests/DebugLogTest.php
+++ b/tests/DebugLogTest.php
@@ -4,6 +4,53 @@ use PHPUnit\Framework\TestCase;
 require __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/../inc/class/eer-debug.class.php';
 
+if (!class_exists('WP_Error')) {
+    class WP_Error {
+        private $errors = [];
+
+        public function __construct($code = '', $message = '', $data = null)
+        {
+            if ($code) {
+                $this->add($code, $message, $data);
+            }
+        }
+
+        public function add($code, $message, $data = null)
+        {
+            $this->errors[$code][] = [
+                'message' => $message,
+                'data'    => $data,
+            ];
+        }
+
+        public function get_error_codes()
+        {
+            return array_keys($this->errors);
+        }
+
+        public function get_error_messages($code = '')
+        {
+            if ($code) {
+                return array_column($this->errors[$code] ?? [], 'message');
+            }
+
+            $all = [];
+            foreach ($this->errors as $items) {
+                foreach ($items as $item) {
+                    $all[] = $item['message'];
+                }
+            }
+
+            return $all;
+        }
+
+        public function get_error_data($code)
+        {
+            return $this->errors[$code][0]['data'] ?? null;
+        }
+    }
+}
+
 class DebugLogTest extends TestCase
 {
     public function test_log_creates_file()
@@ -13,6 +60,18 @@ class DebugLogTest extends TestCase
         EER_Debug::log('hello');
         $this->assertFileExists($log);
         $this->assertStringContainsString('hello', file_get_contents($log));
+        unlink($log);
+    }
+
+    public function test_log_wp_error()
+    {
+        $log = tempnam(sys_get_temp_dir(), 'eer');
+        EER_Debug::init(true, $log);
+        $error = new WP_Error('sample', 'Sample message', ['foo' => 'bar']);
+        EER_Debug::log_wp_error($error);
+        $contents = file_get_contents($log);
+        $this->assertStringContainsString('WP_Error sample: Sample message', $contents);
+        $this->assertStringContainsString('"foo":"bar"', $contents);
         unlink($log);
     }
 }


### PR DESCRIPTION
## Summary
- add `log_wp_error` helper to `EER_Debug` for structured error logging
- log validation failures in `eer-event-sale` worker using new helper
- cover error logging with new PHPUnit test

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a45117d2c08321af05d086efb73a50